### PR TITLE
Enable lint checking in Dart CI

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -20,5 +20,7 @@ jobs:
       run: pub get
     - name: dartfmt
       run: dartfmt lib/ test/ example/ -n;  [ -z $(dartfmt lib/ test/ example/ -n) ] || exit 1
+    - name: linter
+      run: dartanalyzer lib/ test/ example/
     - name: Run unit tests
       run: pub run test

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,8 @@
+include: package:pedantic/analysis_options.yaml
+
+analyzer:
+  # Lint rules and documentation, see http://dart-lang.github.io/linter/lints
+  errors:
+    unused_import: error
+    unused_local_variable: error
+    dead_code: error

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,4 +9,5 @@ environment:
   sdk: ">=2.6.0-dev.6.0 <3.0.0"
 
 dev_dependencies:
+  pedantic: ^1.8.0+1
   test: ^1.9.3

--- a/test/scope_functions_test.dart
+++ b/test/scope_functions_test.dart
@@ -38,7 +38,7 @@ void main() {
         xx = it.length;
       });
       expect(xx, equals(4));
-      expect(target, equals("hoge"));
+      expect(result, equals("hoge"));
     });
   });
 


### PR DESCRIPTION
Without fixing lint errors, CI fails.
![image](https://user-images.githubusercontent.com/11763113/68142897-aa993500-ff73-11e9-96e4-6fa017af5073.png)
