### PR TITLE
bump Dart to 2.6

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image:  google/dart:2.6-dev
+      image:  google/dart:2.6
 
     steps:
     - uses: actions/checkout@v1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   dart:
-    image: google/dart:2.6-dev
+    image: google/dart:2.6
     volumes:
       - .:/kotlin_flavor
     working_dir: /kotlin_flavor


### PR DESCRIPTION
Dart 2.6 is released!

“Announcing Dart 2.6 with dart2native: Compile Dart to self-contained, native executables” by Michael Thomsen https://link.medium.com/lR4fRBQGn1